### PR TITLE
update auth-at-edge semantic version to latest 2.1.7 #709

### DIFF
--- a/deploy/stacks/auth_at_edge.py
+++ b/deploy/stacks/auth_at_edge.py
@@ -23,7 +23,7 @@ class AuthAtEdge(pyNestedClass):
             f'{resource_prefix}-{envname}-authatedge',
             location={
                 'applicationId': 'arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge',
-                'semanticVersion': '2.1.5',
+                'semanticVersion': '2.1.7',
             },
             parameters={
                 'UserPoolArn': userpool_arn,


### PR DESCRIPTION
- Bugfix

### Detail
Node 14 lambda have EOL 2023-04-30, please upgrade dependencies

### Relates
#709

### Security
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
